### PR TITLE
New database fields

### DIFF
--- a/cookie_consent/admin.py
+++ b/cookie_consent/admin.py
@@ -5,13 +5,14 @@ from .models import (
     Cookie,
     CookieGroup,
     LogItem,
+    CookieType,
 )
 
 
 class CookieAdmin(admin.ModelAdmin):
-    list_display = ('varname', 'name', 'cookiegroup', 'path', 'domain',
+    list_display = ('varname', 'name', 'cookiegroup', 'cookietype', 'path', 'domain',
                     'get_version')
-    search_fields = ('name', 'domain', 'cookiegroup__varname',
+    search_fields = ('name', 'domain', 'cookietype__name', 'cookiegroup__varname',
                      'cookiegroup__name')
     readonly_fields = ('varname',)
     list_filter = ('cookiegroup',)
@@ -19,7 +20,7 @@ class CookieAdmin(admin.ModelAdmin):
 
 class CookieGroupAdmin(admin.ModelAdmin):
     list_display = ('varname', 'name', 'is_required', 'is_deletable',
-                    'get_version')
+                    'get_version', 'updated')
     search_fields = ('varname', 'name',)
     list_filter = ('is_required', 'is_deletable',)
 
@@ -31,7 +32,12 @@ class LogItemAdmin(admin.ModelAdmin):
     date_hierarchy = 'created'
 
 
+class CookieTypeAdmin(admin.ModelAdmin):
+    list_display = ('name',) 
+    search_fields = ('name',)
+
 admin.site.register(Cookie, CookieAdmin)
 admin.site.register(CookieGroup, CookieGroupAdmin)
+admin.site.register(CookieType, CookieTypeAdmin)
 if settings.COOKIE_CONSENT_LOG_ENABLED:
     admin.site.register(LogItem, LogItemAdmin)

--- a/cookie_consent/conf.py
+++ b/cookie_consent/conf.py
@@ -5,7 +5,7 @@ from appconf import AppConf
 
 
 class CookieConsentConf(AppConf):
-    NAME = b"cookie_consent"
+    NAME = "cookie_consent"
     MAX_AGE = 60 * 60 * 24 * 365 * 1  # 1 year
     DECLINE = "-1"
 

--- a/cookie_consent/conf.py
+++ b/cookie_consent/conf.py
@@ -5,7 +5,7 @@ from appconf import AppConf
 
 
 class CookieConsentConf(AppConf):
-    NAME = "cookie_consent"
+    NAME = b"cookie_consent"
     MAX_AGE = 60 * 60 * 24 * 365 * 1  # 1 year
     DECLINE = "-1"
 

--- a/cookie_consent/migrations/0003_add_cookietype.py
+++ b/cookie_consent/migrations/0003_add_cookietype.py
@@ -1,0 +1,39 @@
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('cookie_consent', '0002_auto__add_logitem'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='CookieType',
+            fields=[
+                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('name', models.CharField(blank=True, max_length=20, null=True)),
+            ],
+            options={
+                'verbose_name': 'Cookie Type',
+                'verbose_name_plural': 'Cookie Types',
+                'ordering': ('name',),
+            },
+        ),
+        migrations.AddField(
+            model_name='cookie',
+            name='duration',
+            field=models.CharField(blank=True, max_length=256, verbose_name='Duration'),
+        ),
+        migrations.AddField(
+            model_name='cookiegroup',
+            name='updated',
+            field=models.DateTimeField(blank=True, null=True, verbose_name='Updated'),
+        ),
+        migrations.AddField(
+            model_name='cookie',
+            name='cookietype',
+            field=models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.CASCADE, to='cookie_consent.CookieType', verbose_name='Cookie Type'),
+        ),
+    ]

--- a/cookie_consent/models.py
+++ b/cookie_consent/models.py
@@ -33,6 +33,7 @@ class CookieGroup(models.Model):
         default=True)
     ordering = models.IntegerField(_('Ordering'), default=0)
     created = models.DateTimeField(_('Created'), auto_now_add=True, blank=True)
+    updated = models.DateTimeField(_('Updated'), blank=True, null=True)
 
     class Meta:
         verbose_name = _('Cookie Group')
@@ -57,15 +58,34 @@ class CookieGroup(models.Model):
         delete_cache()
 
 
+class CookieType(models.Model):
+    name = models.CharField(max_length=20, blank=True, null=True)
+ 
+    def __str__(self):
+        return self.name
+
+    class Meta:
+        verbose_name = 'Cookie Type'
+        verbose_name_plural = 'Cookie Types'
+        ordering = ('name',)
+
+
 class Cookie(models.Model):
     cookiegroup = models.ForeignKey(
         CookieGroup,
         verbose_name=CookieGroup._meta.verbose_name,
         on_delete=models.CASCADE)
+    cookietype = models.ForeignKey( #new
+        CookieType, 
+        verbose_name=CookieType._meta.verbose_name,
+        blank=True,
+        null=True,
+        on_delete=models.CASCADE)
     name = models.CharField(_('Name'), max_length=250)
     description = models.TextField(_('Description'), blank=True)
     path = models.TextField(_('Path'), blank=True, default="/")
     domain = models.CharField(_('Domain'), max_length=250, blank=True)
+    duration = models.CharField('Duration', max_length=250, blank=True)
     created = models.DateTimeField(_('Created'), auto_now_add=True, blank=True)
 
     class Meta:

--- a/cookie_consent/models.py
+++ b/cookie_consent/models.py
@@ -75,7 +75,7 @@ class Cookie(models.Model):
         CookieGroup,
         verbose_name=CookieGroup._meta.verbose_name,
         on_delete=models.CASCADE)
-    cookietype = models.ForeignKey( #new
+    cookietype = models.ForeignKey(
         CookieType, 
         verbose_name=CookieType._meta.verbose_name,
         blank=True,

--- a/cookie_consent/templates/cookie_consent/_cookie_group.html
+++ b/cookie_consent/templates/cookie_consent/_cookie_group.html
@@ -5,7 +5,9 @@
 <div class="cookie-group">
   <div class="cookie-group-title">
     <h3>{{ cookie_group.name }}</h3>
+    {% if cookie_group.updated %}
     <p> Last updated: {{ cookie_group.updated|date:"m/d/Y" }} </p>
+    {% endif %}
 
     {% if not cookie_group.is_required %}
       <div class="cookie-group-form">

--- a/cookie_consent/templates/cookie_consent/_cookie_group.html
+++ b/cookie_consent/templates/cookie_consent/_cookie_group.html
@@ -5,6 +5,7 @@
 <div class="cookie-group">
   <div class="cookie-group-title">
     <h3>{{ cookie_group.name }}</h3>
+    <p> Last updated: {{ cookie_group.updated|date:"m/d/Y" }} </p>
 
     {% if not cookie_group.is_required %}
       <div class="cookie-group-form">
@@ -34,7 +35,8 @@
     {{ cookie_group.description }}
   </p>
 
-
+<details open>
+  <summary>View cookies</summary>
   <table>
   {% for cookie in cookie_group.cookie_set.all %}
    <tr>
@@ -45,6 +47,16 @@
         {% endif %}
      </th>
      <td>
+       {% if cookie.cookietype %}
+        {{ cookie.cookietype }}
+       {% endif %}
+     </td>
+     <td>
+       {% if cookie.duration %}
+        {{ cookie.duration }}
+       {% endif %}
+     </td>
+     <td>
        {% if cookie.description %}
         {{ cookie.description }}
        {% endif %}
@@ -52,5 +64,6 @@
    </tr>
   {% endfor %}
   </table>
+</details>
 
 </div>


### PR DESCRIPTION
Goes along with issue #34

Regarding number 3 in the underlying issue I did not include anything for that because the cookie group names should be labelled like that rather than have another model/field to categorize them. I based this PR off of Stripe's website. I also added an update field to the cookie group just to show site visitors when the website admins last updated the cookies in that cookie group (since they do change over time). CookieType can be thought of as First party, Third party, Local storage or whatever django admins want to put in there. 