### PR TITLE
Make cookie parsing and serialization more robust

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ dist/
 htmlcov/
 reports/
 testapp/*.db
+.hypothesis
 
 # frontend tooling / builds
 js/node_modules/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ tests = [
     "pytest",
     "pytest-django",
     "pytest-playwright",
+    "hypothesis",
     "tox",
     "isort",
     "black",


### PR DESCRIPTION
Closes #135

Handle some edge cases around malformed cookie strings that may cause crashes. While our own library is not suspected to generate invalid cookie strings, there are ways to bypass input validation of the models and even the cookie value may be set by javascript or people running fuzzers, leading to the cookie value being untrusted input that must be sanitized properly.