### PR TITLE
Drop support for Python 3.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,9 +28,6 @@ jobs:
       matrix:
         python: ['3.10', '3.11', '3.12', '3.13']
         django: ['4.2', '5.1', '5.2']
-        include:
-          - python: '3.9'
-            django: '4.2'
         exclude:
           - python: '3.13'
             django: '4.2'
@@ -64,7 +61,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: '3.12'
 
       - uses: ./.github/actions/build-js
         with:

--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: '3.12'
       - name: Install dependencies
         run: pip install tox
       - run: tox

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,14 +23,13 @@ classifiers = [
     "Operating System :: MacOS",
     "Operating System :: Microsoft :: Windows",
     "Operating System :: OS Independent",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 dependencies = [
     "django>=4.2",
     "django-appconf",

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,5 @@
 [tox]
 envlist =
-    py{39}-django42
     py{310,311,312}-django{42,51,52}
     py{313}-django{51,52}
     isort
@@ -11,7 +10,6 @@ skip_missing_interpreters = true
 
 [gh-actions]
 python =
-    3.9: py39
     3.10: py310
     3.11: py311
     3.12: py312


### PR DESCRIPTION
It will be end-of-life by November 2025. Dropping support allows us to use more modern syntax, in particular for type annotations and pattern matching.