### PR TITLE
Enable django-upgrade

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,3 +3,8 @@ repos:
     rev: v5.0.0
     hooks:
       - id: check-merge-conflict
+
+  - repo: https://github.com/adamchainz/django-upgrade
+    rev: 1.29.1
+    hooks:
+      - id: django-upgrade

--- a/cookie_consent/admin.py
+++ b/cookie_consent/admin.py
@@ -9,6 +9,7 @@ from .conf import settings
 from .models import Cookie, CookieGroup, LogItem
 
 
+@admin.register(Cookie)
 class CookieAdmin(admin.ModelAdmin):
     list_display = ("varname", "name", "cookiegroup", "path", "domain", "get_version")
     search_fields = ("name", "domain", "cookiegroup__varname", "cookiegroup__name")
@@ -16,6 +17,7 @@ class CookieAdmin(admin.ModelAdmin):
     list_filter = ("cookiegroup",)
 
 
+@admin.register(CookieGroup)
 class CookieGroupAdmin(admin.ModelAdmin):
     list_display = (
         "varname",
@@ -58,7 +60,5 @@ class LogItemAdmin(admin.ModelAdmin):
     date_hierarchy = "created"
 
 
-admin.site.register(Cookie, CookieAdmin)
-admin.site.register(CookieGroup, CookieGroupAdmin)
 if settings.COOKIE_CONSENT_LOG_ENABLED:
     admin.site.register(LogItem, LogItemAdmin)

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -37,7 +37,7 @@ class CleanCookiesMiddlewareTests(TestCase):
             consent_response = self.client.post(
                 endpoint,
                 follow=True,
-                HTTP_X_REQUESTED_WITH="XMLHttpRequest",
+                headers={"x-requested-with": "XMLHttpRequest"},
             )
             self.assertEqual(consent_response.status_code, 200)
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -76,7 +76,7 @@ class IntegrationTest(TestCase):
     def test_accept_cookie_ajax(self):
         response = self.client.post(
             reverse("cookie_consent_accept", kwargs={"varname": "optional"}),
-            HTTP_X_REQUESTED_WITH="XMLHttpRequest",
+            headers={"x-requested-with": "XMLHttpRequest"},
         )
         self.assertEqual(response.status_code, 200)
 
@@ -93,7 +93,7 @@ class IntegrationTest(TestCase):
     def test_decline_cookie_ajax(self):
         response = self.client.delete(
             reverse("cookie_consent_decline", kwargs={"varname": "optional"}),
-            HTTP_X_REQUESTED_WITH="XMLHttpRequest",
+            headers={"x-requested-with": "XMLHttpRequest"},
         )
         self.assertEqual(response.status_code, 200)
 


### PR DESCRIPTION
Similar to https://github.com/django-commons/django-cookie-consent/pull/151/commits/4321263bd10c1c16ebbe252a0f22c3f2089de7ee , adds django-upgrade to lint config